### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.1",
         "desarrolla2/cache": "~2.0"
     },
     "require-dev": {

--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -92,7 +92,7 @@ class RateLimiter implements RateLimiterInterface
      *
      * @return ThrottlerInterface
      */
-    private function createThrottler(Data $object, ThrottleSettingsInterface $settings = null)
+    private function createThrottler(Data $object, ?ThrottleSettingsInterface $settings = null)
     {
         if (null === $settings) {
             $settings = $this->defaultSettings;

--- a/src/RateLimiterInterface.php
+++ b/src/RateLimiterInterface.php
@@ -40,5 +40,5 @@ interface RateLimiterInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function get($data, ThrottleSettingsInterface $throttlerSettings = null);
+    public function get($data, ?ThrottleSettingsInterface $throttlerSettings = null);
 }


### PR DESCRIPTION
## What / why
- Fix PHP 8.4 [deprecation warnings](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated):
```
Sunspikes\Ratelimit\RateLimiter::get(): Implicitly marking parameter $settings as nullable is deprecated, the explicit nullable type must be used instead
Sunspikes\Ratelimit\RateLimiter::createThrottler(): Implicitly marking parameter $settings as nullable is deprecated, the explicit nullable type must be used instead
```
- Set minimum PHP version to 7.1 because nullable return types are not supported versions before 7.1: https://www.php.net/manual/en/migration71.new-features.php