### PR TITLE
Fix another PHP 8.4 deprecation warning

### DIFF
--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -71,7 +71,7 @@ class RateLimiter implements RateLimiterInterface
     /**
      * @inheritdoc
      */
-    public function get($data, ThrottleSettingsInterface $settings = null)
+    public function get($data, ?ThrottleSettingsInterface $settings = null)
     {
         if (empty($data)) {
             throw new \InvalidArgumentException('Invalid data, please check the data.');


### PR DESCRIPTION
## What / why
- Fix PHP 8.4 [deprecation warning](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated):
```
Sunspikes\Ratelimit\RateLimiter::get(): Implicitly marking parameter $settings as nullable is deprecated, the explicit nullable type must be used instead
```